### PR TITLE
Add missing keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
 
-    install_requires=list(x.name for x in parse_requirements("./requirements.txt")),
+    install_requires=list(x.name for x in parse_requirements("./requirements.txt", session=False)),
 
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
In newer versions of pip missing session keyword causes errors

``` sh
Collecting minion-ci
  Using cached minion-ci-0.0.6.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-tsgb4nud/minion-ci/setup.py", line 45, in <module>
        install_requires=list(x.name for x in parse_requirements("./requirements.txt")),
      File "/tmp/pip-build-tsgb4nud/minion-ci/setup.py", line 45, in <genexpr>
        install_requires=list(x.name for x in parse_requirements("./requirements.txt")),
      File "/usr/lib64/python3.4/site-packages/pip/req/req_file.py", line 72, in parse_requirements
        "parse_requirements() missing 1 required keyword argument: "
    TypeError: parse_requirements() missing 1 required keyword argument: 'session'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-tsgb4nud/minion-ci
```
