### PR TITLE
use pure python instead of pip magic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ import re
 import sys
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
 if sys.version_info < (3, 4, 1):
     raise RuntimeError("minion-ci requires Python 3.4.1+")
@@ -42,7 +41,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
 
-    install_requires=list(x.name for x in parse_requirements("./requirements.txt", session=False)),
+    install_requires=list(line for line in open("./requirements.txt")),
 
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
```
$ pip3 install minion-ci
Collecting minion-ci
  Downloading minion-ci-0.0.6.tar.gz (41kB)
    100% |################################| 51kB 1.9MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-ubpbra7z/minion-ci/setup.py", line 14, in <module>
        from pip.req import parse_requirements
      File "/usr/lib/python3/dist-packages/pip/__init__.py", line 30, in <module>
        from pip.commands import get_summaries, get_similar_commands
      File "/usr/lib/python3/dist-packages/pip/commands/__init__.py", line 8, in <module>
        from pip.commands.freeze import FreezeCommand
      File "/usr/lib/python3/dist-packages/pip/commands/freeze.py", line 8, in <module>
        from pip.operations.freeze import freeze
      File "/usr/lib/python3/dist-packages/pip/operations/freeze.py", line 12, in <module>
        from pip._vendor.pkg_resources import RequirementParseError
    ImportError: cannot import name 'RequirementParseError'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-ubpbra7z/minion-ci/
```

minion-ci fails to install on a up to date system. And since pip doesn't really support to the use of their internal functions (https://github.com/pypa/pip/issues/2286) so I guess just standard python `open`  should be enough. (Also you should release it to fix all pip installs  :wink:)